### PR TITLE
Several changes and bugfixes from work on Pedestal module

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -9,5 +9,3 @@
 (require '[arachne.buildtools :refer :all])
 
 (read-project-edn!)
-
-(require '[adzerk.boot-test :refer [test]])

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 machine:
   environment:
     BOOT_JVM_OPTIONS: "-Xmx3g"
-    ARACHNE_BUILDTOOLS_VERSION: 0.1.1
+    ARACHNE_BUILDTOOLS_VERSION: 0.2.1
   java:
     version: oraclejdk8
 dependencies:

--- a/project.edn
+++ b/project.edn
@@ -3,8 +3,8 @@
  :description "The abstract HTTP module for the Arachne web framework"
  :license {"Apache Software License 2.0" "http://www.apache.org/licenses/LICENSE-2.0"}
  :deps [[org.clojure/clojure "1.9.0-alpha10" :scope "provided"]
-        [org.arachne-framework/arachne-core
-         ["https://github.com/arachne-framework/arachne-core.git" "d45f410"]]
+        [org.arachne-framework/arachne-core ["git@github.com:arachne-framework/arachne-core.git" "2741a2a4"]]
+        ; [org.arachne-framework/arachne-core ["/Users/luke/src/arachne-framework/arachne-core/.git" "2741a2a4"] :local "../arachne-core"]
         [adzerk/boot-test "1.1.2" :scope "test"]
         [org.clojure/test.check "0.9.0" :scope "test"]
         [org.clojure/tools.namespace "0.2.11" :scope "test"]

--- a/src/arachne/http.clj
+++ b/src/arachne/http.clj
@@ -14,4 +14,4 @@
 (defn configure
   "Configure the core module"
   [cfg]
-  (http-cfg/add-endpoint-dependencies cfg))
+  cfg)

--- a/src/arachne/http/dsl/specs.clj
+++ b/src/arachne/http/dsl/specs.clj
@@ -18,8 +18,10 @@
 (s/def ::http-method #{:options :get :head :post :put :delete :trace :connect})
 
 (s/fdef arachne.http.dsl/endpoint
-  :args (s/cat :method (s/? ::http-method)
-               :methods (s/? (s/coll-of ::http-method :min-count 1))
-               :path string?
-               :impl ::cspec/id
-               :name (s/? keyword?)))
+  :args (s/cat
+          :methods (s/+ ::http-method)
+          :path string?
+          :identity (s/alt
+                      :by-eid (s/cat :eid pos-int? :name keyword?)
+                      :by-arachne-id (s/cat :arachne-id ::cspec/id
+                                       :name (s/? keyword?)))))

--- a/src/arachne/http/schema.clj
+++ b/src/arachne/http/schema.clj
@@ -29,8 +29,8 @@
         :one-or-none :string
         "A regular expression constraining the value of a param or wildcard segment."))
 
-    (o/class :arachne.http/Endpoint []
-      "A resolveable HTTP endpoint."
+    (o/class :arachne.http/Endpoint [:arachne/Component]
+      "A resolveable HTTP endpoint. The concrete type that this entails at runtime is implementation-specific, although all implementations should support instances of arachne.http.Handler as a least common denominator."
       (o/attr :arachne.http.endpoint/route
         :one :arachne.http/RouteSegment
         "Route at which this endpoint can serve")
@@ -39,7 +39,4 @@
         "Unique ID of an endpoint (used for URL generation)")
       (o/attr :arachne.http.endpoint/methods
         :one-or-more :keyword
-        "One or more HTTP methods that this endpoint will respond to. Values should be in #{:options :get :head :post :put :delete :trace :connect}")
-      (o/attr :arachne.http.endpoint/implementation
-        :one :arachne/Component
-        "Reference to a component that actually implements the ability to handle HTTP requests at runtime. What concrete type this entails is implementation-specific, although all implementations should support instances of arachne.http.Handler as a least common denominator."))))
+        "One or more HTTP methods that this endpoint will respond to. Values should be in #{:options :get :head :post :put :delete :trace :connect}"))))

--- a/test/arachne/http/config_test.clj
+++ b/test/arachne/http/config_test.clj
@@ -20,18 +20,10 @@
                    (http/endpoint :get "a/b/c/d" :test/handler-2)
                    (http/endpoint :get "a/b/x/y" :test/handler-3))))
 
-(deftest find-server-dependencies
+(deftest find-endpoints
   (let [cfg (core/build-config "test" '[:org.arachne-framework/arachne-http]
               cfg-init)
         servers (@#'http-cfg/servers cfg)
-        deps (@#'http-cfg/find-server-dependencies cfg (first servers))]
+        deps (@#'http-cfg/find-endpoints cfg (first servers))]
     (is (= 1 (count servers)))
     (is (= 3 (count deps)))))
-
-(deftest server-dependencies-are-added
-  (let [cfg (core/build-config "test" '[:org.arachne-framework/arachne-http]
-              cfg-init)]
-    (is (= 3 (cfg/q cfg '[:find (count ?dep) .
-                          :where
-                          [?server :arachne.http.server/port 8080]
-                          [?server :arachne.component/dependencies ?dep]])))))

--- a/test/arachne/http/dsl_test.clj
+++ b/test/arachne/http/dsl_test.clj
@@ -27,7 +27,6 @@
                  (core/runtime :test/rt [:test/server])
 
                  (core/component :test/handler-1 {} 'test/ctor)
-                 (core/component :test/handler-2 {} 'test/ctor)
                  (core/component :test/handler-3 {} 'test/ctor)
 
                  (http/server :test/server 8080
@@ -36,7 +35,10 @@
 
                    (http/context "/a/b/"
 
-                     (http/endpoint #{:get :head} "/c/*" :test/handler-2)
+                     (http/endpoint :get :head "/c/*"
+                       (core/component :test/handler-2 {} 'test/ctor)
+                       :handler-2-name)
+
                      (http/endpoint :get "/:d(/[0-9]+/)/e" :test/handler-3)))))]
 
     (is (= 1 (cfg/q cfg '[:find (count ?r) .
@@ -56,16 +58,14 @@
 
                      [?end1 :arachne.http.endpoint/name :the-root]
                      [?end1 :arachne.http.endpoint/methods :get]
-                     [?end1 :arachne.http.endpoint/implementation ?i1]
-                     [?i1 :arachne/id :test/handler-1]
+                     [?end1 :arachne/id :test/handler-1]
                      [?end1 :arachne.http.endpoint/route ?server]
                      [?server :arachne.http.server/port 8080]
 
-                     [?end2 :arachne.http.endpoint/name :test/handler-2]
+                     [?end2 :arachne.http.endpoint/name :handler-2-name]
                      [?end2 :arachne.http.endpoint/methods :get]
                      [?end2 :arachne.http.endpoint/methods :head]
-                     [?end2 :arachne.http.endpoint/implementation ?i2]
-                     [?i2 :arachne/id :test/handler-2]
+                     [?end2 :arachne/id :test/handler-2]
                      [?end2 :arachne.http.endpoint/route ?w]
                      [?w :arachne.http.route-segment/wildcard true]
                      [?w :arachne.http.route-segment/parent ?c]
@@ -78,8 +78,7 @@
 
                      [?end3 :arachne.http.endpoint/name :test/handler-3]
                      [?end3 :arachne.http.endpoint/methods :get]
-                     [?end3 :arachne.http.endpoint/implementation ?i3]
-                     [?i3 :arachne/id :test/handler-3]
+                     [?end3 :arachne/id :test/handler-3]
                      [?end3 :arachne.http.endpoint/route ?e]
                      [?e :arachne.http.route-segment/pattern "e"]
                      [?e :arachne.http.route-segment/parent ?d]


### PR DESCRIPTION
- endpoints now are components, instead of having components
- tweak endpoint DSL
- make HTTP config helper functions more reusable
- dependency keys are now optional
- no longer set up concrete component dependencies; that is the impl's job
